### PR TITLE
Add Movement multi-agent example

### DIFF
--- a/python/agents/mov-agent/README.md
+++ b/python/agents/mov-agent/README.md
@@ -1,0 +1,16 @@
+# Movement Agent (mov-agent)
+
+The **mov-agent** is a multi-agent demo inspired by the Movement web application. It demonstrates how Google ADK can orchestrate a set of specialized sub‑agents to help students plan, execute, and reflect on their learning journey.
+
+The root agent welcomes the user, interprets the request, and delegates to the most relevant sub-agent:
+
+- **VisionAgent** – guides students to craft a 3–5‑year vision.
+- **GoalAgent** – helps break the vision into SMART goals and prioritized tasks.
+- **ReviewAgent** – runs active‑recall sessions on specific tasks.
+- **FeedbackAgent** – gathers reflections and self‑assessments.
+- **DataAgent** – performs CRUD operations through Firebase Data Connect.
+- **CriticAgent** – (optional) checks task plans for feasibility and balance.
+- **ChitChatAgent** – handles small talk or motivation.
+- **TherapistAgent** – provides supportive conversation when a student is struggling.
+
+This sample focuses on the agent architecture rather than full functionality. Firebase interactions and detailed prompts would be filled in for a production deployment.

--- a/python/agents/mov-agent/mov_agent/__init__.py
+++ b/python/agents/mov-agent/mov_agent/__init__.py
@@ -1,0 +1,6 @@
+"""Initialization for mov-agent."""
+import os
+
+MODEL = os.getenv("GOOGLE_GENAI_MODEL", "gemini-2.0-pro")
+
+from . import agent  # noqa: E402  # pylint: disable=wrong-import-position

--- a/python/agents/mov-agent/mov_agent/agent.py
+++ b/python/agents/mov-agent/mov_agent/agent.py
@@ -1,0 +1,30 @@
+"""Root agent for Movement demo."""
+from google.adk.agents import Agent
+
+from . import MODEL, root_agent_prompt
+from .sub_agents.vision_agent import VisionAgent
+from .sub_agents.goal_agent import GoalAgent
+from .sub_agents.review_agent import ReviewAgent
+from .sub_agents.feedback_agent import FeedbackAgent
+from .sub_agents.data_agent import DataAgent
+from .sub_agents.critic_agent import CriticAgent
+from .sub_agents.chitchat_agent import ChitChatAgent
+from .sub_agents.therapist_agent import TherapistAgent
+
+
+root_agent = Agent(
+    model=MODEL,
+    name="mov_root_agent",
+    description="Routes requests to specialized Movement agents",
+    instruction=root_agent_prompt.PROMPT,
+    sub_agents=[
+        VisionAgent,
+        GoalAgent,
+        ReviewAgent,
+        FeedbackAgent,
+        DataAgent,
+        CriticAgent,
+        ChitChatAgent,
+        TherapistAgent,
+    ],
+)

--- a/python/agents/mov-agent/mov_agent/root_agent_prompt.py
+++ b/python/agents/mov-agent/mov_agent/root_agent_prompt.py
@@ -1,0 +1,9 @@
+"""Prompt for mov-agent root agent."""
+
+PROMPT = """
+You are Movement, a friendly AI study companion. Welcome the user and understand their request.
+Depending on their need, transfer control to one of your specialist agents:
+VisionAgent, GoalAgent, ReviewAgent, FeedbackAgent, DataAgent, CriticAgent, ChitChatAgent or TherapistAgent.
+If an agent cannot fulfill the request, return here and route to another agent.
+Always keep responses supportive and student-focused.
+"""

--- a/python/agents/mov-agent/mov_agent/sub_agents/__init__.py
+++ b/python/agents/mov-agent/mov_agent/sub_agents/__init__.py
@@ -1,0 +1,20 @@
+"""Sub-agent exports for mov-agent."""
+from .vision_agent import VisionAgent
+from .goal_agent import GoalAgent
+from .review_agent import ReviewAgent
+from .feedback_agent import FeedbackAgent
+from .data_agent import DataAgent
+from .critic_agent import CriticAgent
+from .chitchat_agent import ChitChatAgent
+from .therapist_agent import TherapistAgent
+
+__all__ = [
+    "VisionAgent",
+    "GoalAgent",
+    "ReviewAgent",
+    "FeedbackAgent",
+    "DataAgent",
+    "CriticAgent",
+    "ChitChatAgent",
+    "TherapistAgent",
+]

--- a/python/agents/mov-agent/mov_agent/sub_agents/chitchat_agent.py
+++ b/python/agents/mov-agent/mov_agent/sub_agents/chitchat_agent.py
@@ -1,0 +1,12 @@
+"""ChitChat agent for Movement."""
+from google.adk.agents import Agent
+
+from .. import MODEL
+from . import chitchat_agent_prompt
+
+ChitChatAgent = Agent(
+    model=MODEL,
+    name="chitchat_agent",
+    description="Handle off-topic or motivational conversation",
+    instruction=chitchat_agent_prompt.PROMPT,
+)

--- a/python/agents/mov-agent/mov_agent/sub_agents/chitchat_agent_prompt.py
+++ b/python/agents/mov-agent/mov_agent/sub_agents/chitchat_agent_prompt.py
@@ -1,0 +1,6 @@
+"""Prompt for ChitChatAgent."""
+
+PROMPT = """
+Engage in friendly conversation or offer motivation when the user is off-topic.
+Keep responses upbeat and brief before returning to the root agent or another requested agent.
+"""

--- a/python/agents/mov-agent/mov_agent/sub_agents/critic_agent.py
+++ b/python/agents/mov-agent/mov_agent/sub_agents/critic_agent.py
@@ -1,0 +1,12 @@
+"""Critic agent for Movement."""
+from google.adk.agents import Agent
+
+from .. import MODEL
+from . import critic_agent_prompt
+
+CriticAgent = Agent(
+    model=MODEL,
+    name="critic_agent",
+    description="Validate plans for feasibility",
+    instruction=critic_agent_prompt.PROMPT,
+)

--- a/python/agents/mov-agent/mov_agent/sub_agents/critic_agent_prompt.py
+++ b/python/agents/mov-agent/mov_agent/sub_agents/critic_agent_prompt.py
@@ -1,0 +1,6 @@
+"""Prompt for CriticAgent."""
+
+PROMPT = """
+Review proposed plans and tasks for feasibility and balance.
+Provide constructive suggestions before returning control to the root agent.
+"""

--- a/python/agents/mov-agent/mov_agent/sub_agents/data_agent.py
+++ b/python/agents/mov-agent/mov_agent/sub_agents/data_agent.py
@@ -1,0 +1,12 @@
+"""Data agent for Movement."""
+from google.adk.agents import Agent
+
+from .. import MODEL
+from . import data_agent_prompt
+
+DataAgent = Agent(
+    model=MODEL,
+    name="data_agent",
+    description="Perform CRUD operations via Firebase",
+    instruction=data_agent_prompt.PROMPT,
+)

--- a/python/agents/mov-agent/mov_agent/sub_agents/data_agent_prompt.py
+++ b/python/agents/mov-agent/mov_agent/sub_agents/data_agent_prompt.py
@@ -1,0 +1,6 @@
+"""Prompt for DataAgent."""
+
+PROMPT = """
+Handle create, read, update, and delete operations for users, visions, goals and tasks.
+Use Firebase Data Connect according to the database schema.
+"""

--- a/python/agents/mov-agent/mov_agent/sub_agents/feedback_agent.py
+++ b/python/agents/mov-agent/mov_agent/sub_agents/feedback_agent.py
@@ -1,0 +1,12 @@
+"""Feedback agent for Movement."""
+from google.adk.agents import Agent
+
+from .. import MODEL
+from . import feedback_agent_prompt
+
+FeedbackAgent = Agent(
+    model=MODEL,
+    name="feedback_agent",
+    description="Gather reflections and self-assessments",
+    instruction=feedback_agent_prompt.PROMPT,
+)

--- a/python/agents/mov-agent/mov_agent/sub_agents/feedback_agent_prompt.py
+++ b/python/agents/mov-agent/mov_agent/sub_agents/feedback_agent_prompt.py
@@ -1,0 +1,6 @@
+"""Prompt for FeedbackAgent."""
+
+PROMPT = """
+Ask how the study session went. Collect reflections and self-assessment data.
+Store notes using DataAgent and then return to ChitChatAgent for closing conversation.
+"""

--- a/python/agents/mov-agent/mov_agent/sub_agents/goal_agent.py
+++ b/python/agents/mov-agent/mov_agent/sub_agents/goal_agent.py
@@ -1,0 +1,12 @@
+"""Goal agent for Movement."""
+from google.adk.agents import Agent
+
+from .. import MODEL
+from . import goal_agent_prompt
+
+GoalAgent = Agent(
+    model=MODEL,
+    name="goal_agent",
+    description="Create goals and tasks from the student's vision",
+    instruction=goal_agent_prompt.PROMPT,
+)

--- a/python/agents/mov-agent/mov_agent/sub_agents/goal_agent_prompt.py
+++ b/python/agents/mov-agent/mov_agent/sub_agents/goal_agent_prompt.py
@@ -1,0 +1,6 @@
+"""Prompt for GoalAgent."""
+
+PROMPT = """
+Using the student's vision, collaborate with them to create specific SMART goals.
+Break goals into prioritized tasks using the Eisenhower matrix. Hand off to ReviewAgent when planning is complete.
+"""

--- a/python/agents/mov-agent/mov_agent/sub_agents/review_agent.py
+++ b/python/agents/mov-agent/mov_agent/sub_agents/review_agent.py
@@ -1,0 +1,12 @@
+"""Review agent for Movement."""
+from google.adk.agents import Agent
+
+from .. import MODEL
+from . import review_agent_prompt
+
+ReviewAgent = Agent(
+    model=MODEL,
+    name="review_agent",
+    description="Lead active recall sessions on tasks",
+    instruction=review_agent_prompt.PROMPT,
+)

--- a/python/agents/mov-agent/mov_agent/sub_agents/review_agent_prompt.py
+++ b/python/agents/mov-agent/mov_agent/sub_agents/review_agent_prompt.py
@@ -1,0 +1,6 @@
+"""Prompt for ReviewAgent."""
+
+PROMPT = """
+Conduct an active-recall session on the student's current tasks or study topics.
+Encourage them to explain concepts and reflect on progress. When finished, transfer to FeedbackAgent.
+"""

--- a/python/agents/mov-agent/mov_agent/sub_agents/therapist_agent.py
+++ b/python/agents/mov-agent/mov_agent/sub_agents/therapist_agent.py
@@ -1,0 +1,12 @@
+"""Therapist agent for Movement."""
+from google.adk.agents import Agent
+
+from .. import MODEL
+from . import therapist_agent_prompt
+
+TherapistAgent = Agent(
+    model=MODEL,
+    name="therapist_agent",
+    description="Support users when they are stressed or upset",
+    instruction=therapist_agent_prompt.PROMPT,
+)

--- a/python/agents/mov-agent/mov_agent/sub_agents/therapist_agent_prompt.py
+++ b/python/agents/mov-agent/mov_agent/sub_agents/therapist_agent_prompt.py
@@ -1,0 +1,6 @@
+"""Prompt for TherapistAgent."""
+
+PROMPT = """
+When the user seems stressed or upset, respond empathetically.
+Guide them through their concerns and suggest healthy coping strategies.
+"""

--- a/python/agents/mov-agent/mov_agent/sub_agents/vision_agent.py
+++ b/python/agents/mov-agent/mov_agent/sub_agents/vision_agent.py
@@ -1,0 +1,12 @@
+"""Vision agent for Movement."""
+from google.adk.agents import Agent
+
+from .. import MODEL
+from . import vision_agent_prompt
+
+VisionAgent = Agent(
+    model=MODEL,
+    name="vision_agent",
+    description="Guide students to craft a 3–5 year vision",
+    instruction=vision_agent_prompt.PROMPT,
+)

--- a/python/agents/mov-agent/mov_agent/sub_agents/vision_agent_prompt.py
+++ b/python/agents/mov-agent/mov_agent/sub_agents/vision_agent_prompt.py
@@ -1,0 +1,6 @@
+"""Prompt for VisionAgent."""
+
+PROMPT = """
+You help students articulate a clear 3–5 year vision for their studies and career.
+Ask about their interests, values and desired outcomes. Summarize the vision and then transfer to GoalAgent.
+"""

--- a/python/agents/mov-agent/pyproject.toml
+++ b/python/agents/mov-agent/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "mov-agent"
+version = "0.1.0"
+description = "Movement multi-agent demo"
+authors = [{name = "Example", email = "example@example.com"}]
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+    "google-adk>=1.0.0",
+]


### PR DESCRIPTION
## Summary
- add new sample agent `mov-agent` to demonstrate Movement use case
- implement root agent and sub-agents (vision, goal, review, feedback, data, critic, chitchat, therapist)
- document agent purpose and structure in README

## Testing
- `python -m compileall python/agents/mov-agent`

------
https://chatgpt.com/codex/tasks/task_e_684d043c9e18832b80ac9c67a66c8ef4